### PR TITLE
add timeout to yices using its option for that

### DIFF
--- a/SMT/src/org/smtlib/solvers/Solver_yices2.java
+++ b/SMT/src/org/smtlib/solvers/Solver_yices2.java
@@ -144,6 +144,13 @@ public class Solver_yices2 extends Solver_smt implements ISolver {
 		if (res.isError()) return res;
 
 		try {
+			if (smtConfig.timeout>0) {
+				String sq = solverProcess.sendAndListen("(set-timeout "+(int)smtConfig.timeout+")\r\n");
+				if (sq.contains(errorIndication)) {
+					return smtConfig.responseFactory.error(sq);
+				}
+				
+			}
 			String s = solverProcess.sendAndListen("(check)\r\n");
 			if (s.contains(errorIndication)) {
 				return smtConfig.responseFactory.error(s);


### PR DESCRIPTION
Yices 2 can support a timeout, but this is not honored by jSMTlib currently. This option sets the timeout option for the next checkSat call, so we have to pass the option at each checkSat call in the adapter.

Caveat :  This is not an overall timeout since the solver is started however, since you can chain checkSat calls (so I believe this is different from z3 semantics of timeout where the option is a command line flag when starting the solver). However it's the best we can do easily (i.e. without monitoring the process, or counting elapsed time from outside the yices process) to honour the fact a timeout behavior (>0) has been set at jSMTlib SMTConfiguration level.
 
See option description in [Yices manual](http://yices.csl.sri.com/papers/manual.pdf) : 
This timeout will apply to the next call to (check), but not to the one after that.  After
every call to (check), the timeout is reset to 0 (which means no timeout).  One can also
clear the timeout explicitly by setting it to 0
