### PR TITLE
Use toPlainString() instead of toString() for decimals

### DIFF
--- a/SMT/src/org/smtlib/sexpr/Printer.java
+++ b/SMT/src/org/smtlib/sexpr/Printer.java
@@ -131,7 +131,7 @@ public class Printer implements IPrinter, org.smtlib.IVisitor</*@Nullable*/ Void
 	/*@Nullable*/
 	@Override
 	public Void visit(IDecimal e) throws IVisitor.VisitorException {
-		try { w.append(e.value().toString()); } catch (IOException ex) { throw new IVisitor.VisitorException(ex); }
+		try { w.append(e.value().toPlainString()); } catch (IOException ex) { throw new IVisitor.VisitorException(ex); }
 		return null;
 	}
 


### PR DESCRIPTION
Prevents low-magnitude numbers from being converted to scientific notation, as seen in https://github.com/OpenJML/OpenJML/issues/737